### PR TITLE
fix: put NOTPROVIDED code in correct position

### DIFF
--- a/Builder/CreditTransfer.php
+++ b/Builder/CreditTransfer.php
@@ -102,7 +102,15 @@ class CreditTransfer extends Base {
 
             $creditorAgent = $this->createElement('CdtrAgt');
             $financialInstitution = $this->createElement('FinInstnId');
-            $financialInstitution->appendChild($this->createElement('BIC', $payment->getCreditorBIC()));
+            
+            if ($payment->getCreditorBIC() === 'NOTPROVIDED') {
+                $financialInstitutionOther = $this->createElement('Othr');
+                $financialInstitutionOther->appendChild($this->createElement('Id', $payment->getCreditorBIC()));
+                $financialInstitution->appendChild($financialInstitutionOther);
+            } else {
+                $financialInstitution->appendChild($this->createElement('BIC', $payment->getCreditorBIC()));
+            }
+            
             $creditorAgent->appendChild($financialInstitution);
             $creditTransferTransactionInformation->appendChild($creditorAgent);
 


### PR DESCRIPTION
Hi @perryfaro,

Thank you for creating this library. I've made a small adjustment to it regarding not-provided BIC codes. When you set the Creditor BIC to `NOTPROVIDED` (also the default value), the library currently transforms that into:

```xml
<CdtrAgt>
  <FinInstnId>
    <BIC>NOTPROVIDED</BIC>
  </FinInstnId>
</CdtrAgt>
```

In PAIN.001.001.03, `NOTPROVIDED` is only a valid value when provided via Othr/Id. This PR fixes that.

New (correct) output:

```xml
<CdtrAgt>
  <FinInstnId>
    <Othr>
      <Id>NOTPROVIDED</Id>
    </Othr>
  </FinInstnId>
</CdtrAgt>
```