### PR TITLE
CreDtTm 19 characters SEPA-defined

### DIFF
--- a/Builder/CreditTransfer.php
+++ b/Builder/CreditTransfer.php
@@ -31,7 +31,7 @@ class CreditTransfer extends Base {
         $messageIdentification = $this->createElement('MsgId', $groupHeader->getMessageIdentification());
         $groupHeaderElement->appendChild($messageIdentification);
 
-        $creationDateTime = $this->createElement('CreDtTm', $groupHeader->getCreationDateTime()->format('Y-m-d\TH:i:s\Z'));
+        $creationDateTime = $this->createElement('CreDtTm', $groupHeader->getCreationDateTime()->format('Y-m-d\TH:i:s'));
         $groupHeaderElement->appendChild($creationDateTime);
 
         $numberOfTransactions = $this->createElement('NbOfTxs', $groupHeader->getNumberOfTransactions());


### PR DESCRIPTION
SEPA scheme defines 19 characters for the tag  CreDtTm. Some banks do accept the last character Z, but some others don't.

![Selection_288](https://user-images.githubusercontent.com/61022311/131385437-71872def-4214-4780-abf8-38aa25fb597a.png)


Please, apply this fix to the library. 

Thanks